### PR TITLE
improved display of header

### DIFF
--- a/src/dashboard/DashboardStyles.ts
+++ b/src/dashboard/DashboardStyles.ts
@@ -11,7 +11,7 @@ export const HeaderContainer = styled.div`
   align-items: center;
   justify-content: center;
   width: 98%;
-  padding: 0;
+  padding: 12px;
   position: relative;
   height: 12vh;
 `;

--- a/src/dashboard/dashboard.tsx
+++ b/src/dashboard/dashboard.tsx
@@ -383,16 +383,17 @@ const Dashboard: React.FC = () => {
 
   return (
     <DashboardContainer>
-      <HeaderContainer>
-        <SelectionContainer style={{width: '60px', left:'0', position: 'absolute'}}>
-            <label style={{ fontSize: '14px', marginBottom: '4px' }}>{t.languageLabel}</label>
-            <SelectDropdown style={{  padding: '4px'}}>
+      <HeaderContainer style={{marginBottom: '4px'}}>
+        <SelectionContainer style={{width: '60px', left:'0', position: 'absolute', paddingLeft: '0px'}}>
+            <label style={{ fontSize: '14px', marginBottom: '4px', paddingTop: '10px', }}>{t.languageLabel}</label>
+            <SelectDropdown style={{  padding: '4px', height: '100%', position: 'relative'}}>
               <DropdownOption
                 key="en"
                 onClick={() => handleLanguageChange('en')}
                 style={{
                   fontWeight: selectedLanguage === 'en' ? 'bold' : 'normal',
                   color: selectedLanguage === 'en' ? '#007bff' : 'black',
+                  padding: '2px'
                 }}
               >
                 English
@@ -403,6 +404,7 @@ const Dashboard: React.FC = () => {
                 style={{
                   fontWeight: selectedLanguage === "ja" ? "bold" : "normal",
                   color: selectedLanguage === "ja" ? "#007bff" : "black",
+                  padding: '2px'
                 }}
               >
                 Japanese
@@ -413,6 +415,7 @@ const Dashboard: React.FC = () => {
                 style={{
                   fontWeight: selectedLanguage === 'ar' ? 'bold' : 'normal',
                   color: selectedLanguage === 'ar' ? '#007bff' : 'black',
+                  padding: '2px'
                 }}
               >
                 Arabic


### PR DESCRIPTION
Adjusted padding/margins of various header elements to ensure the language box is fully visible and aligns better with both the QR code and left-hand map.

<img width="1301" alt="Updated alignment screenshot" src="https://github.com/user-attachments/assets/922eb8df-2330-4fc8-90e8-8842927fd22e" />
